### PR TITLE
Disable default overview post, and use simple pages

### DIFF
--- a/ponty-connector/ponty-connector.php
+++ b/ponty-connector/ponty-connector.php
@@ -24,7 +24,9 @@ class Pnty_Connector {
             unset($wp_post_types[PNTY_PTNAME]);
         }
         delete_option('pnty_api_key');
+        delete_option('pnty_remove_archive');
         delete_option('pnty_slug');
+        delete_option('pnty_remove_showcase_archive');
         delete_option('pnty_slug_showcase');
         delete_option('pnty_extcss');
         delete_option('pnty_ogtag');
@@ -172,12 +174,15 @@ class Pnty_Connector {
             'singular_name' => __('Ponty job', 'pnty')
         );
 
+        $remove_archive = (bool) (get_option('pnty_remove_archive') ?? false);
+
         $job_args = array(
             'description' => __('Ponty jobs', 'pnty'),
             'public' => false,
             'publicly_queryable' => true,
+            'show_in_rest' => true,
             'exclude_from_search' => false,
-            'has_archive' => true,
+            'has_archive' => !$remove_archive,
             'show_ui' => false,
             'rewrite' => array(
                 'slug' => 'jobs',
@@ -197,13 +202,16 @@ class Pnty_Connector {
         register_post_type(PNTY_PTNAME, $job_args);
     }
 
+    
     function create_post_type_showcase() {
+        $remove_showcase_archive = (bool) (get_option('pnty_remove_showcase_archive') ?? false);
+
         $showcase_args = array(
             'description' => __('Terminated Ponty jobs', 'pnty'),
             'public' => false,
             'publicly_queryable' => true,
             'exclude_from_search' => false,
-            'has_archive' => true,
+            'has_archive' => !$this->remove_showcase_archive,
             'show_ui' => false,
             'rewrite' => array(
                 'slug' => 'showcase-jobs',
@@ -759,8 +767,12 @@ function pnty_admin_init(){
     if (delete_transient('pnty_slug_saved')) flush_rewrite_rules();
     add_option('pnty_api_key', '');
     register_setting('pnty_options', 'pnty_api_key');
+    add_option('pnty_remove_archive', false);
+    register_setting('pnty_options', 'pnty_remove_archive', 'pnty_slug_save');
     add_option('pnty_slug', 'jobs');
     register_setting('pnty_options', 'pnty_slug', 'pnty_slug_save');
+    add_option('pnty_remove_showcase_archive', false);
+    register_setting('pnty_options', 'pnty_remove_showcase_archive', 'pnty_slug_save');
     add_option('pnty_slug_showcase', 'showcase-jobs');
     register_setting('pnty_options', 'pnty_slug_showcase', 'pnty_slug_save');
     add_option('pnty_extcss', null);

--- a/ponty-connector/ponty-connector.php
+++ b/ponty-connector/ponty-connector.php
@@ -211,7 +211,7 @@ class Pnty_Connector {
             'public' => false,
             'publicly_queryable' => true,
             'exclude_from_search' => false,
-            'has_archive' => !$this->remove_showcase_archive,
+            'has_archive' => !$remove_showcase_archive,
             'show_ui' => false,
             'rewrite' => array(
                 'slug' => 'showcase-jobs',

--- a/ponty-connector/ponty-connector.php
+++ b/ponty-connector/ponty-connector.php
@@ -26,8 +26,10 @@ class Pnty_Connector {
         delete_option('pnty_api_key');
         delete_option('pnty_remove_archive');
         delete_option('pnty_slug');
+        delete_option('pnty_show_ui');
         delete_option('pnty_remove_showcase_archive');
         delete_option('pnty_slug_showcase');
+        delete_option('pnty_show_terminated_ui');
         delete_option('pnty_extcss');
         delete_option('pnty_ogtag');
         delete_option('pnty_jsonld');
@@ -156,6 +158,8 @@ class Pnty_Connector {
     }
 
     function create_post_type() {
+        $show_ui = (bool) (get_option('pnty_show_ui') ?? false);
+
         $tag_labels = array(
             'name' => __('Ponty job tags', 'pnty')
         );
@@ -183,7 +187,7 @@ class Pnty_Connector {
             'show_in_rest' => true,
             'exclude_from_search' => false,
             'has_archive' => !$remove_archive,
-            'show_ui' => false,
+            'show_ui' => $show_ui,
             'rewrite' => array(
                 'slug' => 'jobs',
                 'with_front' => false
@@ -205,6 +209,7 @@ class Pnty_Connector {
     
     function create_post_type_showcase() {
         $remove_showcase_archive = (bool) (get_option('pnty_remove_showcase_archive') ?? false);
+        $show_terminated_ui = (bool) (get_option('pnty_show_terminated_ui') ?? false);
 
         $showcase_args = array(
             'description' => __('Terminated Ponty jobs', 'pnty'),
@@ -212,7 +217,7 @@ class Pnty_Connector {
             'publicly_queryable' => true,
             'exclude_from_search' => false,
             'has_archive' => !$remove_showcase_archive,
-            'show_ui' => false,
+            'show_ui' => $show_terminated_ui,
             'rewrite' => array(
                 'slug' => 'showcase-jobs',
                 'with_front' => false
@@ -771,10 +776,14 @@ function pnty_admin_init(){
     register_setting('pnty_options', 'pnty_remove_archive', 'pnty_slug_save');
     add_option('pnty_slug', 'jobs');
     register_setting('pnty_options', 'pnty_slug', 'pnty_slug_save');
+    add_option('pnty_show_ui', false);
+    register_setting('pnty_options', 'pnty_show_ui');
     add_option('pnty_remove_showcase_archive', false);
     register_setting('pnty_options', 'pnty_remove_showcase_archive', 'pnty_slug_save');
     add_option('pnty_slug_showcase', 'showcase-jobs');
     register_setting('pnty_options', 'pnty_slug_showcase', 'pnty_slug_save');
+    add_option('pnty_show_terminated_ui', false);
+    register_setting('pnty_options', 'pnty_show_terminated_ui');
     add_option('pnty_extcss', null);
     register_setting('pnty_options', 'pnty_extcss');
     add_option('pnty_ogtag', false);

--- a/ponty-connector/settings-page.php
+++ b/ponty-connector/settings-page.php
@@ -2,8 +2,10 @@
     $pnty_api_key = get_option('pnty_api_key');
     $remove_archive = (bool) (get_option('pnty_remove_archive') ?? false);
     $pnty_slug = get_option('pnty_slug');
+    $show_ui = (bool) (get_option('pnty_show_ui') ?? false);
     $remove_showcase_archive = (bool) (get_option('pnty_remove_showcase_archive') ?? false);
     $pnty_slug_showcase = get_option('pnty_slug_showcase');
+    $show_terminated_ui = (bool) (get_option('pnty_show_terminated_ui') ?? false);
     $pnty_extcss = get_option('pnty_extcss');
     $pnty_ogtag = get_option('pnty_ogtag');
     $pnty_jsonld = get_option('pnty_jsonld');
@@ -62,6 +64,15 @@
                     </tr>
                     <tr valign="top">
                         <th scope="row">
+                            <label for="pnty_show_ui"><?php _e('Show UI', 'pnty');?></label>
+                        </th>
+                        <td>
+                            <input type="checkbox" id="pnty_show_ui" name="pnty_show_ui" value="true" <?php echo ($show_ui) ? 'checked="checked"': '';?> />
+                            <p class="description"><?php _e('Show the ads on the WordPress admin dashboard.', 'pnty'); ?></p>
+                        </td>
+                    </tr>
+                    <tr valign="top">
+                        <th scope="row">
                             <label for="pnty_remove_showcase_archive"><?php _e('Remove showcase archive', 'pnty');?></label>
                         </th>
                         <td>
@@ -76,6 +87,15 @@
                         <td>
                             <input type="text" id="pnty_slug_showcase" name="pnty_slug_showcase" value="<?php echo $pnty_slug_showcase;?>" />
                             <p class="description"><?php _e('What url slug should prefix the showcase jobs. Default is <strong>showcase-jobs</strong>.', 'pnty'); ?></p>
+                        </td>
+                    </tr>
+                    <tr valign="top">
+                        <th scope="row">
+                            <label for="pnty_show_terminated_ui"><?php _e('Show UI (Terminated)', 'pnty');?></label>
+                        </th>
+                        <td>
+                            <input type="checkbox" id="pnty_show_terminated_ui" name="pnty_show_terminated_ui" value="true" <?php echo ($show_terminated_ui) ? 'checked="checked"': '';?> />
+                            <p class="description"><?php _e('Show the terminated ads on the WordPress admin dashboard.', 'pnty'); ?></p>
                         </td>
                     </tr>
                     <tr valign="top">

--- a/ponty-connector/settings-page.php
+++ b/ponty-connector/settings-page.php
@@ -1,6 +1,8 @@
 <?php
     $pnty_api_key = get_option('pnty_api_key');
+    $remove_archive = (bool) (get_option('pnty_remove_archive') ?? false);
     $pnty_slug = get_option('pnty_slug');
+    $remove_showcase_archive = (bool) (get_option('pnty_remove_showcase_archive') ?? false);
     $pnty_slug_showcase = get_option('pnty_slug_showcase');
     $pnty_extcss = get_option('pnty_extcss');
     $pnty_ogtag = get_option('pnty_ogtag');
@@ -42,11 +44,29 @@
                     </tr>
                     <tr valign="top">
                         <th scope="row">
+                        <label for="remove_archive">Remove archive (<?php _e('overview page');?>)</label>
+                        </th>
+                        <td>
+                            <input type="checkbox" id="remove_archive" name="pnty_remove_archive" value="true" <?php echo ($remove_archive) ? 'checked="checked"': '';?> />
+                            <p class="description"><?php _e('Select if you like to use a custom <strong>page</strong> for the overview.', 'pnty'); ?></p>
+                        </td>
+                    </tr>
+                    <tr valign="top">
+                        <th scope="row">
                         <label for="pnty_slug">URL slug (<?php _e('active ads');?>)</label>
                         </th>
                         <td>
                             <input type="text" id="pnty_slug" name="pnty_slug" value="<?php echo $pnty_slug;?>" />
                             <p class="description"><?php _e('What url slug should prefix the jobs. Default is <strong>jobs</strong>.', 'pnty'); ?></p>
+                        </td>
+                    </tr>
+                    <tr valign="top">
+                        <th scope="row">
+                            <label for="pnty_remove_showcase_archive"><?php _e('Remove showcase archive', 'pnty');?></label>
+                        </th>
+                        <td>
+                            <input type="checkbox" id="pnty_remove_showcase_archive" name="pnty_remove_showcase_archive" value="true" <?php echo ($remove_showcase_archive) ? 'checked="checked"': '';?> />
+                            <p class="description"><?php _e('Select if you like to use a custom <strong>page</strong> for the showcase overview.', 'pnty'); ?></p>
                         </td>
                     </tr>
                     <tr valign="top">


### PR DESCRIPTION
Sometimes, we need to create a custom WordPress page, instead of the default overview page. Disabling has_archive based on the developer's need, we can enable them to use their own "pages" as listing pages.